### PR TITLE
Fix CJ intro walk loop and improved task debug

### DIFF
--- a/sphene/src/client/debug/debug.lua
+++ b/sphene/src/client/debug/debug.lua
@@ -383,7 +383,7 @@ function Debug.pause()
             rotation = { getElementRotation(element) },
         }
 
-        --setElementFrozen(element, true)
+        setElementFrozen(element, true)
     end
 
     for _, element in ipairs(getElementsByType('actor')) do
@@ -397,7 +397,7 @@ function Debug.pause()
             rotation = { getElementRotation(element) },
         }
 
-        --setElementFrozen(element, true)
+        setElementFrozen(element, true)
     end
 
     Debug.paused = true
@@ -779,6 +779,25 @@ function Debug.actorDebugRender()
 
                                 infoYPosition = infoYPosition + 28 * (1920 / screenWidth)
                             end
+
+                            local debugParams = task:getDebugParameters()
+
+                            if debugParams then
+                                for property, param in pairs(debugParams) do
+                                    if type(param) == 'table' then
+                                        param = Debug.prettifyTable(param)
+                                    end
+
+                                    dxDrawText("    "..property..": "..param, sx + 20 * (1920 / screenWidth), infoYPosition + 2 * (1920 / screenWidth), screenWidth,
+                                        infoYPosition + 2 * (1920 / screenWidth),
+                                        tocolor(0, 0, 0, 255), 1.6 * (1920 / screenWidth), "default", "left", "top", false, false, false, true)
+
+                                    dxDrawText("    "..property..": "..param, sx + 20 * (1920 / screenWidth), infoYPosition, screenWidth, infoYPosition,
+                                        tocolor(255, 255, 255, 255), 1.6 * (1920 / screenWidth), "default", "left", "top", false, false, false, true)
+
+                                    infoYPosition = infoYPosition + 28 * (1920 / screenWidth)
+                                end
+                            end
                         end
                     end
 
@@ -901,9 +920,9 @@ function Debug.actorDebugRender()
 
                         dxDrawText("Moveable: "..tostring(Pad.isMoveable() or false), sx + 10 * (1920 / screenWidth), infoYPosition, screenWidth, infoYPosition,
                             tocolor(255, 255, 255, 255), 1.6 * (1920 / screenWidth), "default", "left", "top", false, false, false, true)
-                    end
 
-                    infoYPosition = infoYPosition + 28 * (1920 / screenWidth)
+                        infoYPosition = infoYPosition + 28 * (1920 / screenWidth)
+                    end
 
                     if (actor.element) then
                         infoYPosition = infoYPosition + 28 * (1920 / screenWidth)

--- a/sphene/src/client/debug/debug.lua
+++ b/sphene/src/client/debug/debug.lua
@@ -782,7 +782,7 @@ function Debug.actorDebugRender()
 
                             local debugParams = task:getDebugParameters()
 
-                            if debugParams then
+                            if next(debugParams) ~= nil then
                                 for property, param in pairs(debugParams) do
                                     if type(param) == 'table' then
                                         param = Debug.prettifyTable(param)

--- a/sphene/src/client/debug/debug.lua
+++ b/sphene/src/client/debug/debug.lua
@@ -782,7 +782,7 @@ function Debug.actorDebugRender()
 
                             local debugParams = task:getDebugParameters()
 
-                            if next(debugParams) ~= nil then
+                            if debugParams then
                                 for property, param in pairs(debugParams) do
                                     if type(param) == 'table' then
                                         param = Debug.prettifyTable(param)

--- a/sphene/src/client/game/elements/tasks/san_andreas/simple/taskSimpleGoToPoint.lua
+++ b/sphene/src/client/game/elements/tasks/san_andreas/simple/taskSimpleGoToPoint.lua
@@ -62,7 +62,7 @@ function TaskSimpleGoToPoint:process()
     if node == nil then
         ped:setAnalogControlState("forwards", 0)
         ped:setControlState("walk", false)
-        
+
         self:setFinished()
         return
     end
@@ -83,7 +83,6 @@ end
 
 function TaskSimpleGoToPoint:getDebugParameters()
     local ped = self:getPed()
-    local x, y, z = ped:getPosition()
 
     return {
         Position = string.format("x: %.2f, y: %.2f, z: %.2f", self.x, self.y, self.z),

--- a/sphene/src/client/game/elements/tasks/san_andreas/simple/taskSimpleGoToPoint.lua
+++ b/sphene/src/client/game/elements/tasks/san_andreas/simple/taskSimpleGoToPoint.lua
@@ -47,9 +47,11 @@ function TaskSimpleGoToPoint:process()
     end
 
     local ped = self:getPed()
+    local distance = ped:distanceTo(self.x, self.y, self.z)
 
-    if (ped:distanceTo(self.x, self.y, self.z) < 0.1) then
+    if distance <= 1 then
         ped:setAnalogControlState("forwards", 0)
+        ped:setControlState("walk", false)
 
         self:setFinished()
         return
@@ -58,11 +60,11 @@ function TaskSimpleGoToPoint:process()
     local node = self.path:findNextWaypoint(1)
 
     if node == nil then
-        node = {
-            x = self.x,
-            y = self.y,
-            z = self.z,
-        }
+        ped:setAnalogControlState("forwards", 0)
+        ped:setControlState("walk", false)
+        
+        self:setFinished()
+        return
     end
 
     local x, y, _ = ped:getPosition()
@@ -72,10 +74,21 @@ function TaskSimpleGoToPoint:process()
 
     ped:setRotation(rotX, rotY, -angle)
     ped:setAnalogControlState("forwards", 1)
+    ped:setControlState("walk", true)
 end
 
 function TaskSimpleGoToPoint:getName()
     return "TASK_SIMPLE_GO_TO_POINT"
+end
+
+function TaskSimpleGoToPoint:getDebugParameters()
+    local ped = self:getPed()
+    local x, y, z = ped:getPosition()
+
+    return {
+        Position = string.format("x: %.2f, y: %.2f, z: %.2f", self.x, self.y, self.z),
+        Distance = string.format("%.2f", ped:distanceTo(self.x, self.y, self.z))
+    }
 end
 
 Task.register(0x05C5, TaskSimpleGoToPoint)

--- a/sphene/src/client/game/elements/tasks/task.lua
+++ b/sphene/src/client/game/elements/tasks/task.lua
@@ -90,12 +90,7 @@ function Task:getName()
 end
 
 function Task:getDebugParameters()
-    return {
-        {
-            name = "ped",
-            type = "element:ped",
-        }
-    }
+    return {}
 end
 
 function Task.register(id, class)


### PR DESCRIPTION
Fixes #13 

PR fixes the problem that causes CJ to be stuck in a walk loop on the intro. This isn't a permanent fix as the GO_TO_POINT task is still in development.

Also adds improved debugging for tasks by making it possible to add debug parameters to the screen.